### PR TITLE
Accept spotify URLs in post me player queue

### DIFF
--- a/shpotify
+++ b/shpotify
@@ -315,6 +315,10 @@ case "$verb" in
                   spotify:track:*)
                     spotify_api_call POST "v1/me/player/queue?uri=$5"
                     ;;
+                  https://open.spotify.com/track/*)
+                    track=${${5##*/}%\?*}
+                    spotify_api_call POST "v1/me/player/queue?uri=spotify:track:$track"
+                    ;;
                   *) die "" ;;
                 esac
                 ;;


### PR DESCRIPTION
This recognizes track URLs (rather than just IDs) when adding to the queue. Example:

```sh
shpotify post me player queue "https://open.spotify.com/track/4DtVxUEnutSt5IXefyO90w?si=fb45ae7d24ff4ad9"
```